### PR TITLE
fix: trim whitespace from host and IP zod schemas

### DIFF
--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -47,7 +47,7 @@ export type CacheType = "fetch" | "cache";
 
 export const domain = z
 	.object({
-		host: z.string().min(1, { message: "Add a hostname" }),
+		host: z.string().trim().min(1, { message: "Add a hostname" }),
 		path: z.string().min(1).optional(),
 		port: z
 			.number()

--- a/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
@@ -44,7 +44,7 @@ const Schema = z.object({
 		message: "Name is required",
 	}),
 	description: z.string().optional(),
-	ipAddress: z.string().min(1, {
+	ipAddress: z.string().trim().min(1, {
 		message: "IP Address is required",
 	}),
 	port: z.number().optional(),

--- a/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
@@ -34,7 +34,7 @@ const Schema = z.object({
 		message: "Name is required",
 	}),
 	description: z.string().optional(),
-	ipAddress: z.string().min(1, {
+	ipAddress: z.string().trim().min(1, {
 		message: "IP Address is required",
 	}),
 	port: z.number().optional(),

--- a/apps/dokploy/components/dashboard/settings/web-server/update-server-ip.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server-ip.tsx
@@ -33,7 +33,7 @@ import { toast } from "sonner";
 import { z } from "zod";
 
 const schema = z.object({
-	serverIp: z.string(),
+	serverIp: z.string().trim(),
 });
 
 type Schema = z.infer<typeof schema>;

--- a/apps/dokploy/server/api/routers/domain.ts
+++ b/apps/dokploy/server/api/routers/domain.ts
@@ -233,7 +233,7 @@ export const domainRouter = createTRPCRouter({
 		.input(
 			z.object({
 				domain: z.string(),
-				serverIp: z.string().optional(),
+				serverIp: z.string().trim().optional(),
 			}),
 		)
 		.mutation(async ({ input }) => {

--- a/apps/dokploy/server/db/validations/domain.ts
+++ b/apps/dokploy/server/db/validations/domain.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const domain = z
 	.object({
-		host: z.string().min(1, { message: "Add a hostname" }),
+		host: z.string().trim().min(1, { message: "Add a hostname" }),
 		path: z.string().min(1).optional(),
 		port: z
 			.number()
@@ -31,9 +31,10 @@ export const domain = z
 		}
 	});
 
+
 export const domainCompose = z
 	.object({
-		host: z.string().min(1, { message: "Host is required" }),
+		host: z.string().trim().min(1, { message: "Host is required" }),
 		path: z.string().min(1).optional(),
 		port: z
 			.number()

--- a/packages/server/src/db/schema/ai.ts
+++ b/packages/server/src/db/schema/ai.ts
@@ -65,7 +65,7 @@ export const deploySuggestionSchema = z.object({
 	domains: z
 		.array(
 			z.object({
-				host: z.string().min(1),
+				host: z.string().trim().min(1),
 				port: z.number().min(1),
 				serviceName: z.string().min(1),
 			}),

--- a/packages/server/src/db/validations/domain.ts
+++ b/packages/server/src/db/validations/domain.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const domain = z
 	.object({
-		host: z.string().min(1, { message: "Add a hostname" }),
+		host: z.string().trim().min(1, { message: "Add a hostname" }),
 		path: z.string().min(1).optional(),
 		port: z
 			.number()
@@ -31,9 +31,10 @@ export const domain = z
 		}
 	});
 
+
 export const domainCompose = z
 	.object({
-		host: z.string().min(1, { message: "Host is required" }),
+		host: z.string().trim().min(1, { message: "Host is required" }),
 		path: z.string().min(1).optional(),
 		port: z
 			.number()

--- a/packages/server/src/services/ai.ts
+++ b/packages/server/src/services/ai.ts
@@ -129,9 +129,9 @@ export const suggestVariants = async ({
 									value: z.string(),
 								}),
 							),
-							domains: z.array(
+								domains: z.array(
 								z.object({
-									host: z.string(),
+									host: z.string().trim(),
 									port: z.number(),
 									serviceName: z.string(),
 								}),


### PR DESCRIPTION
### Before Picture
<img width="1512" height="982" alt="Before Dokploy Issue 1" src="https://github.com/user-attachments/assets/7d73468b-f24d-4720-a041-c36316971484" />

### Description
Normalize host/IP inputs by trimming leading/trailing whitespace in zod validators and key form/router schemas. This prevents SSH failures caused by padded addresses.

- What: add .trim() to host/ip/serverIp schemas across validators, forms and router input.
- Test: enter " 1.2.3.4 " or " example.com " in the UI and confirm stored value has no surrounding spaces.

Fixes #6

### After Picture
<img width="1512" height="982" alt="After Dokploy Issue 1" src="https://github.com/user-attachments/assets/62afa1c7-3fd6-4cc0-bd52-47a57f1cfeb7" />

### Video Explanation
https://github.com/user-attachments/assets/956dc388-773f-4720-b577-9c2e77a53d2b

