### PR TITLE
security: mask basic-auth password with ToggleVisibilityInput

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/security/handle-security.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/security/handle-security.tsx
@@ -18,6 +18,7 @@ import {
 	FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { api } from "@/utils/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PenBoxIcon, PlusIcon } from "lucide-react";
@@ -151,7 +152,16 @@ export const HandleSecurity = ({
 									<FormItem>
 										<FormLabel>Password</FormLabel>
 										<FormControl>
-											<Input placeholder="test" {...field} />
+											{/* Prevent internal buttons from triggering form submit by
+												cancelling the click default action at the component boundary.
+												This avoids changing the shared ToggleVisibilityInput file. */}
+											<div onClickCapture={(e) => e.preventDefault()}>
+												<ToggleVisibilityInput
+													placeholder="test"
+													value={field.value || ""}
+													onChange={(e) => field.onChange(e.target.value)}
+												/>
+											</div>
 										</FormControl>
 
 										<FormMessage />

--- a/apps/dokploy/components/dashboard/application/advanced/security/show-security.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/security/show-security.tsx
@@ -11,6 +11,7 @@ import { api } from "@/utils/api";
 import { LockKeyhole, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { HandleSecurity } from "./handle-security";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 
 interface Props {
 	applicationId: string;
@@ -68,9 +69,12 @@ export const ShowSecurity = ({ applicationId }: Props) => {
 											</div>
 											<div className="flex flex-col gap-1">
 												<span className="font-medium">Password</span>
-												<span className="text-sm text-muted-foreground">
-													{security.password}
-												</span>
+												<div className="text-sm text-muted-foreground max-w-full">
+													<ToggleVisibilityInput
+														disabled
+														value={security.password}
+													/>
+												</div>
 											</div>
 										</div>
 										<div className="flex flex-row gap-2">


### PR DESCRIPTION
### Before Pictures
<img width="1512" height="982" alt="Screenshot 2025-10-05 at 2 35 13 PM" src="https://github.com/user-attachments/assets/1c43209e-b044-4dc4-a892-75863473c9cf" />
<img width="1512" height="982" alt="Screenshot 2025-10-05 at 2 35 34 PM" src="https://github.com/user-attachments/assets/d5e96128-5eca-4213-aa74-08559cdc607b" />


### Description
Title: Mask basic-auth password & add visibility toggle

Fixes #9

Description: Replace plain-text password input/display with ToggleVisibilityInput in the Security dialog and listing so passwords are masked by default and can be shown/copied. Prevent icon clicks from submitting the form.

How to test:
- App → Advanced → Security: add/edit shows masked password with eye/copy controls; create/update still submits.

### After Pictures
<img width="1512" height="982" alt="Screenshot 2025-10-05 at 2 46 45 PM" src="https://github.com/user-attachments/assets/3c63fcb5-e7fb-4dab-9f25-884df1139269" />
<img width="1512" height="982" alt="Screenshot 2025-10-05 at 2 46 33 PM" src="https://github.com/user-attachments/assets/c1d64efc-3057-443f-8b1a-0cf108544bf8" />


### Video Explanation
https://github.com/user-attachments/assets/8dd1e829-a276-49fc-9c09-44d68978e93f


