### PR TITLE
feat: add display name to profile and sidebar

### DIFF
--- a/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
+++ b/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
@@ -37,6 +37,7 @@ const profileSchema = z.object({
 	currentPassword: z.string().nullable(),
 	image: z.string().optional(),
 	allowImpersonation: z.boolean().optional().default(false),
+	name: z.string().optional(),
 });
 
 type Profile = z.infer<typeof profileSchema>;
@@ -84,6 +85,7 @@ export const ProfileForm = () => {
 			image: data?.user?.image || "",
 			currentPassword: "",
 			allowImpersonation: data?.user?.allowImpersonation || false,
+			name: data?.user?.name || "",
 		},
 		resolver: zodResolver(profileSchema),
 	});
@@ -97,12 +99,14 @@ export const ProfileForm = () => {
 					image: data?.user?.image || "",
 					currentPassword: form.getValues("currentPassword") || "",
 					allowImpersonation: data?.user?.allowImpersonation,
+					name: data?.user?.name || "",
 				},
 				{
 					keepValues: true,
 				},
 			);
 			form.setValue("allowImpersonation", data?.user?.allowImpersonation);
+			form.setValue("name", data?.user?.name || "");
 
 			if (data.user.email) {
 				generateSHA256Hash(data.user.email).then((hash) => {
@@ -119,6 +123,7 @@ export const ProfileForm = () => {
 			image: values.image,
 			currentPassword: values.currentPassword || undefined,
 			allowImpersonation: values.allowImpersonation,
+			name: values.name,
 		})
 			.then(async () => {
 				await refetch();
@@ -128,6 +133,7 @@ export const ProfileForm = () => {
 					password: "",
 					image: values.image,
 					currentPassword: "",
+					name: values.name,
 				});
 			})
 			.catch(() => {
@@ -167,6 +173,22 @@ export const ProfileForm = () => {
 										className="grid gap-4"
 									>
 										<div className="space-y-4">
+											<FormField
+												control={form.control}
+												name="name"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Display Name</FormLabel>
+														<FormControl>
+															<Input
+																placeholder="Enter your display name"
+																{...field}
+															/>
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
 											<FormField
 												control={form.control}
 												name="email"

--- a/apps/dokploy/components/layouts/user-nav.tsx
+++ b/apps/dokploy/components/layouts/user-nav.tsx
@@ -49,7 +49,7 @@ export const UserNav = () => {
 						<AvatarFallback className="rounded-lg">CN</AvatarFallback>
 					</Avatar>
 					<div className="grid flex-1 text-left text-sm leading-tight">
-						<span className="truncate font-semibold">Account</span>
+						<span className="truncate font-semibold">{data?.user?.name || "Account"}</span>
 						<span className="truncate text-xs">{data?.user?.email}</span>
 					</div>
 					<ChevronsUpDown className="ml-auto size-4" />


### PR DESCRIPTION
### Description
Add an optional display name to the profile settings and show it in the sidebar. This lets users personalize their profile and improves identification across the interface. The value is optional, loaded from the existing profile, saved on update, and displayed instead of the Account label.

### What
- Add optional name field to the profile form schema
- Initialize and reset name in form state
- Include name in the profile update request payload
- Add a Display Name input to the profile form
- Show the user’s name in the sidebar with a fallback to Account

### Test
- Navigate to Settings > Profile and confirm a Display Name input is visible
- Enter a name (for example, Jane Doe) and save; expect success, sidebar shows the name; refresh and confirm persistence
- Clear the name and save; expect success, sidebar falls back to Account
- Change to a different name and save; verify the new value persists and appears in the sidebar

Fixes #13 


### Before Picture
<img width="1512" height="982" alt="Screenshot 2025-10-19 at 8 32 42 PM" src="https://github.com/user-attachments/assets/08e78dee-5ad1-4330-9e80-3485a8eb170f" />

### After Picture
<img width="1512" height="982" alt="Screenshot 2025-10-19 at 8 31 50 PM" src="https://github.com/user-attachments/assets/6a3159c3-9740-4119-a7d3-f1cc71c2bd8f" />

### Video Explanation
https://github.com/user-attachments/assets/a31e4bb2-5b6a-42db-8d20-7d5275dc483a


