### PR TITLE
fix: validate profile email on client and server

### DIFF
--- a/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
+++ b/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
@@ -32,7 +32,11 @@ import { Disable2FA } from "./disable-2fa";
 import { Enable2FA } from "./enable-2fa";
 
 const profileSchema = z.object({
-	email: z.string(),
+	email: z
+ 		.string()
+ 		.trim()
+ 		.min(1, "Email is required")
+ 		.email("Enter a valid email address"),
 	password: z.string().nullable(),
 	currentPassword: z.string().nullable(),
 	image: z.string().optional(),

--- a/packages/server/src/db/schema/user.ts
+++ b/packages/server/src/db/schema/user.ts
@@ -296,6 +296,7 @@ export const apiUpdateWebServerMonitoring = z.object({
 });
 
 export const apiUpdateUser = createSchema.partial().extend({
+	email: z.string().trim().min(1, "Email is required").email("Enter a valid email address").optional(),
 	password: z.string().optional(),
 	currentPassword: z.string().optional(),
 	metricsConfig: z


### PR DESCRIPTION
### Description
The profile settings page allowed saving an empty or malformed email address. Although the UI showed a success message, this created an inconsistent account state: authentication rejects empty/invalid emails, causing sign-in failures after a profile update.

### What
- Add client-side Zod validation.
- Add server-side Zod validation
- No DB schema changes were made.

### Test
- On Profile page:
  - Clear the email field and click Save -> Expect inline error “Email is required” and no submission.
  - Enter invalid emails (`notanemail`, `test@`, `@example.com`) and click Save -> Expect inline error “Enter a valid email address” and no submission.
  - Enter a valid email `name@example.com` and click Save -> Expect success toast and profile updated.
- Bypass client-side validation:
  - Send a crafted `user.update` request with `"email": ""` or `"email": "notanemail"` -> Expect server-side validation error and no update.
- Sign-out and sign-in after valid update -> Expect successful login with updated email.

Fixes #18

### Before 
<img width="1512" height="982" alt="Screenshot 2025-11-02 at 5 50 46 PM" src="https://github.com/user-attachments/assets/d95e6604-0e40-42ec-8edd-12bbbd1b9186" />

### After
<img width="1512" height="982" alt="Screenshot 2025-11-02 at 5 02 55 PM" src="https://github.com/user-attachments/assets/54a26ba7-0cea-4f6b-b894-1ce39274b9b0" />
<img width="1512" height="982" alt="Screenshot 2025-11-02 at 5 02 41 PM" src="https://github.com/user-attachments/assets/b2f93ac3-9b26-4f53-b23c-0a02e1dc20bf" />

### Video Explanation
https://github.com/user-attachments/assets/53888b15-2c33-4ccb-884c-2a1d95008fea




