### PR TITLE
feat: add Cmd+K / Ctrl+K keyboard shortcut for search inputs

### DIFF
--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { api } from "@/utils/api";
+import { useSearchShortcut } from "@/utils/hooks/use-search-shortcut";
 import {
 	AlertTriangle,
 	BookIcon,
@@ -43,7 +44,7 @@ import {
 	TrashIcon,
 } from "lucide-react";
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { HandleProject } from "./handle-project";
 import { ProjectEnvironment } from "./project-environment";
@@ -54,6 +55,10 @@ export const ShowProjects = () => {
 	const { data: auth } = api.user.get.useQuery();
 	const { mutateAsync } = api.project.remove.useMutation();
 	const [searchQuery, setSearchQuery] = useState("");
+	const searchInputRef = useRef<HTMLInputElement>(null);
+
+	// Enable Cmd+K / Ctrl+K keyboard shortcut for search input
+	useSearchShortcut(searchInputRef);
 
 	const filteredProjects = useMemo(() => {
 		if (!data) return [];
@@ -100,6 +105,7 @@ export const ShowProjects = () => {
 								<>
 									<div className="w-full relative">
 										<Input
+											ref={searchInputRef}
 											placeholder="Filter projects..."
 											value={searchQuery}
 											onChange={(e) => setSearchQuery(e.target.value)}

--- a/apps/dokploy/pages/dashboard/project/[projectId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId].tsx
@@ -67,6 +67,7 @@ import {
 import { cn } from "@/lib/utils";
 import { appRouter } from "@/server/api/root";
 import { api } from "@/utils/api";
+import { useSearchShortcut } from "@/utils/hooks/use-search-shortcut";
 import type { findProjectById } from "@dokploy/server";
 import { validateRequest } from "@dokploy/server/lib/auth";
 import { createServerSideHelpers } from "@trpc/react-query/server";
@@ -91,7 +92,13 @@ import type {
 } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { type ReactElement, useEffect, useMemo, useState } from "react";
+import {
+	type ReactElement,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { toast } from "sonner";
 import superjson from "superjson";
 
@@ -275,6 +282,11 @@ const Project = (
 	const applications = extractServices(data);
 
 	const [searchQuery, setSearchQuery] = useState("");
+	const searchInputRef = useRef<HTMLInputElement>(null);
+
+	// Enable Cmd+K / Ctrl+K keyboard shortcut for search input
+	useSearchShortcut(searchInputRef);
+
 	const serviceTypes = [
 		{ value: "application", label: "Application", icon: GlobeIcon },
 		{ value: "postgres", label: "PostgreSQL", icon: PostgresqlIcon },
@@ -846,6 +858,7 @@ const Project = (
 										<div className="flex flex-col gap-2 lg:flex-row lg:gap-4 lg:items-center">
 											<div className="w-full relative">
 												<Input
+													ref={searchInputRef}
 													placeholder="Filter services..."
 													value={searchQuery}
 													onChange={(e) => setSearchQuery(e.target.value)}

--- a/apps/dokploy/utils/hooks/use-search-shortcut.ts
+++ b/apps/dokploy/utils/hooks/use-search-shortcut.ts
@@ -1,0 +1,52 @@
+import { type RefObject, useEffect } from "react";
+
+/**
+ * Custom hook that adds Cmd+K (Mac) or Ctrl+K (Windows/Linux) keyboard shortcut
+ * to focus a search input element.
+ *
+ * @param searchInputRef - React ref pointing to the search input element
+ *
+ * @example
+ * ```tsx
+ * const searchInputRef = useRef<HTMLInputElement>(null);
+ * useSearchShortcut(searchInputRef);
+ *
+ * return <input ref={searchInputRef} placeholder="Search..." />;
+ * ```
+ */
+export function useSearchShortcut(
+	searchInputRef: RefObject<HTMLInputElement>,
+) {
+	useEffect(() => {
+		const handleKeyDown = (event: KeyboardEvent) => {
+			// Check if Cmd+K (Mac) or Ctrl+K (Windows/Linux) was pressed
+			const isShortcut = (event.metaKey || event.ctrlKey) && event.key === "k";
+
+			if (!isShortcut) return;
+
+			// Don't trigger if user is already typing in an input field
+			const activeElement = document.activeElement;
+			const isTyping =
+				activeElement instanceof HTMLInputElement ||
+				activeElement instanceof HTMLTextAreaElement ||
+				activeElement instanceof HTMLSelectElement ||
+				activeElement?.hasAttribute("contenteditable");
+
+			if (isTyping) return;
+
+			// Prevent browser's default Cmd+K behavior (e.g., address bar focus)
+			event.preventDefault();
+
+			// Focus the search input
+			searchInputRef.current?.focus();
+		};
+
+		// Attach event listener
+		document.addEventListener("keydown", handleKeyDown);
+
+		// Cleanup on unmount
+		return () => {
+			document.removeEventListener("keydown", handleKeyDown);
+		};
+	}, [searchInputRef]);
+}


### PR DESCRIPTION
- Create reusable useSearchShortcut hook for global keyboard shortcuts
- Implement conflict prevention (don't trigger when typing in other inputs)
- Add keyboard shortcut to Projects page "Filter projects..." input
- Add keyboard shortcut to Services page "Filter services..." input
- Support both Mac (Cmd+K) and Windows/Linux (Ctrl+K) automatically
- Prevent the browser's default Cmd+K behavior

Improves keyboard-first navigation and accessibility for power users.

Fixes #31 


_N.B.: Before and after screenshots not provided in this instance, as no noticeable difference can be detected through screenshots for this specific feature_


### Video Explanation
https://github.com/user-attachments/assets/eae12d94-7f4b-453d-86d7-551222489c95

