### PR TITLE
feat: add custom title/description support for API deployments

### DIFF
--- a/apps/dokploy/pages/api/deploy/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/[refreshToken].ts
@@ -36,7 +36,15 @@ export default async function handler(
 			return;
 		}
 
-		const deploymentTitle = extractCommitMessage(req.headers, req.body);
+		// Check for custom title/description in request body (for direct API calls)
+		const customTitle =
+			typeof req.body?.title === "string" ? req.body.title : null;
+		const customDescription =
+			typeof req.body?.description === "string" ? req.body.description : null;
+
+		// Use custom values if provided, otherwise extract from webhook payload
+		const deploymentTitle =
+			customTitle || extractCommitMessage(req.headers, req.body);
 		const deploymentHash = extractHash(req.headers, req.body);
 
 		const sourceType = application.sourceType;
@@ -179,10 +187,18 @@ export default async function handler(
 		}
 
 		try {
+			// Use custom description if provided, otherwise use hash
+			const descriptionLog =
+				customDescription !== null
+					? customDescription
+					: deploymentHash
+						? `Hash: ${deploymentHash}`
+						: "";
+
 			const jobData: DeploymentJob = {
 				applicationId: application.applicationId as string,
 				titleLog: deploymentTitle,
-				descriptionLog: `Hash: ${deploymentHash}`,
+				descriptionLog,
 				type: "deploy",
 				applicationType: "application",
 				server: !!application.serverId,

--- a/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
@@ -43,7 +43,15 @@ export default async function handler(
 			return;
 		}
 
-		const deploymentTitle = extractCommitMessage(req.headers, req.body);
+		// Check for custom title/description in request body (for direct API calls)
+		const customTitle =
+			typeof req.body?.title === "string" ? req.body.title : null;
+		const customDescription =
+			typeof req.body?.description === "string" ? req.body.description : null;
+
+		// Use custom values if provided, otherwise extract from webhook payload
+		const deploymentTitle =
+			customTitle || extractCommitMessage(req.headers, req.body);
 		const deploymentHash = extractHash(req.headers, req.body);
 		const sourceType = composeResult.sourceType;
 
@@ -165,12 +173,20 @@ export default async function handler(
 		}
 
 		try {
+			// Use custom description if provided, otherwise use hash
+			const descriptionLog =
+				customDescription !== null
+					? customDescription
+					: deploymentHash
+						? `Hash: ${deploymentHash}`
+						: "";
+
 			const jobData: DeploymentJob = {
 				composeId: composeResult.composeId as string,
 				titleLog: deploymentTitle,
 				type: "deploy",
 				applicationType: "compose",
-				descriptionLog: `Hash: ${deploymentHash}`,
+				descriptionLog,
 				server: !!composeResult.serverId,
 			};
 

--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -6,8 +6,10 @@ import {
 import { db } from "@/server/db";
 import {
 	apiCreateApplication,
+	apiDeployApplication,
 	apiFindMonitoringStats,
 	apiFindOneApplication,
+	apiRedeployApplication,
 	apiReloadApplication,
 	apiSaveBitbucketProvider,
 	apiSaveBuildType,
@@ -298,7 +300,7 @@ export const applicationRouter = createTRPCRouter({
 		}),
 
 	redeploy: protectedProcedure
-		.input(apiFindOneApplication)
+		.input(apiRedeployApplication)
 		.mutation(async ({ input, ctx }) => {
 			const application = await findApplicationById(input.applicationId);
 			if (
@@ -311,8 +313,8 @@ export const applicationRouter = createTRPCRouter({
 			}
 			const jobData: DeploymentJob = {
 				applicationId: input.applicationId,
-				titleLog: "Rebuild deployment",
-				descriptionLog: "",
+				titleLog: input.title || "Rebuild deployment",
+				descriptionLog: input.description || "",
 				type: "redeploy",
 				applicationType: "application",
 				server: !!application.serverId,
@@ -648,7 +650,7 @@ export const applicationRouter = createTRPCRouter({
 			return true;
 		}),
 	deploy: protectedProcedure
-		.input(apiFindOneApplication)
+		.input(apiDeployApplication)
 		.mutation(async ({ input, ctx }) => {
 			const application = await findApplicationById(input.applicationId);
 			if (
@@ -661,8 +663,8 @@ export const applicationRouter = createTRPCRouter({
 			}
 			const jobData: DeploymentJob = {
 				applicationId: input.applicationId,
-				titleLog: "Manual deployment",
-				descriptionLog: "",
+				titleLog: input.title || "Manual deployment",
+				descriptionLog: input.description || "",
 				type: "deploy",
 				applicationType: "application",
 				server: !!application.serverId,

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -3,9 +3,11 @@ import { db } from "@/server/db";
 import {
 	apiCreateCompose,
 	apiDeleteCompose,
+	apiDeployCompose,
 	apiFetchServices,
 	apiFindCompose,
 	apiRandomizeCompose,
+	apiRedeployCompose,
 	apiUpdateCompose,
 	compose as composeTable,
 } from "@/server/db/schema";
@@ -315,7 +317,7 @@ export const composeRouter = createTRPCRouter({
 		}),
 
 	deploy: protectedProcedure
-		.input(apiFindCompose)
+		.input(apiDeployCompose)
 		.mutation(async ({ input, ctx }) => {
 			const compose = await findComposeById(input.composeId);
 
@@ -327,10 +329,10 @@ export const composeRouter = createTRPCRouter({
 			}
 			const jobData: DeploymentJob = {
 				composeId: input.composeId,
-				titleLog: "Manual deployment",
+				titleLog: input.title || "Manual deployment",
 				type: "deploy",
 				applicationType: "compose",
-				descriptionLog: "",
+				descriptionLog: input.description || "",
 				server: !!compose.serverId,
 			};
 
@@ -349,7 +351,7 @@ export const composeRouter = createTRPCRouter({
 			);
 		}),
 	redeploy: protectedProcedure
-		.input(apiFindCompose)
+		.input(apiRedeployCompose)
 		.mutation(async ({ input, ctx }) => {
 			const compose = await findComposeById(input.composeId);
 			if (compose.project.organizationId !== ctx.session.activeOrganizationId) {
@@ -360,10 +362,10 @@ export const composeRouter = createTRPCRouter({
 			}
 			const jobData: DeploymentJob = {
 				composeId: input.composeId,
-				titleLog: "Rebuild deployment",
+				titleLog: input.title || "Rebuild deployment",
 				type: "redeploy",
 				applicationType: "compose",
-				descriptionLog: "",
+				descriptionLog: input.description || "",
 				server: !!compose.serverId,
 			};
 			if (IS_CLOUD && compose.serverId) {

--- a/packages/server/src/db/schema/application.ts
+++ b/packages/server/src/db/schema/application.ts
@@ -446,6 +446,16 @@ export const apiFindOneApplication = createSchema
 	})
 	.required();
 
+export const apiDeployApplication = apiFindOneApplication.extend({
+	title: z.string().max(255).optional(),
+	description: z.string().max(1000).optional(),
+});
+
+export const apiRedeployApplication = apiFindOneApplication.extend({
+	title: z.string().max(255).optional(),
+	description: z.string().max(1000).optional(),
+});
+
 export const apiReloadApplication = createSchema
 	.pick({
 		appName: true,

--- a/packages/server/src/db/schema/compose.ts
+++ b/packages/server/src/db/schema/compose.ts
@@ -177,6 +177,16 @@ export const apiFindCompose = z.object({
 	composeId: z.string().min(1),
 });
 
+export const apiDeployCompose = apiFindCompose.extend({
+	title: z.string().max(255).optional(),
+	description: z.string().max(1000).optional(),
+});
+
+export const apiRedeployCompose = apiFindCompose.extend({
+	title: z.string().max(255).optional(),
+	description: z.string().max(1000).optional(),
+});
+
 export const apiDeleteCompose = z.object({
 	composeId: z.string().min(1),
 	deleteVolumes: z.boolean(),


### PR DESCRIPTION
### Summary

- Add optional title and description parameters to deployment endpoints
- Support custom deployment labels via TRPC API and external webhook endpoints
- Maintain full backward compatibility with existing integrations

### Problem
Deployments triggered via the API or CLI are labeled with generic titles like "Manual deployment" or "Rebuild deployment," making it impossible to distinguish between different deployments in the history. Only webhook-triggered deployments benefit from descriptive labels (using commit messages).

### Solution
Added optional title (max 255 chars) and description (max 1000 chars) parameters to:
- TRPC: application.deploy, application.redeploy, compose.deploy, compose.redeploy
- External API: /api/deploy/[refreshToken], /api/deploy/compose/[refreshToken]
- When not provided, existing default titles are used (backward compatible).

### Test Plan
- Schema validation tests pass (16 tests)
- TypeScript check passes
- TRPC endpoints accept custom title/description
- External webhook API accepts custom title/description
- Schema correctly rejects titles > 255 chars
- Invalid types gracefully fall back to defaults
- Backward compatibility verified (endpoints work without new params)


Closes #14


### Before and After
https://github.com/user-attachments/assets/01d9fd4b-8d8a-43f0-9c98-41ceac158ae7

### Code Walkthrough
https://github.com/user-attachments/assets/7e10b874-979a-4922-a680-bbc10bb8bfa4



